### PR TITLE
Update package dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(
     license='BSD',
     python_requires='>=2.7',
     install_requires=[
-        'antlr4-python2-runtime==4.5',
-        'antlr4-python3-runtime==4.5',
-        'enum34'
+        'antlr4-python2-runtime==4.5; python_version<"3"',
+        'antlr4-python3-runtime==4.5; python_version>="3"',
+        'enum34; python_version<"3.4"'
     ],
     package_data={'': ['*.so']},
     packages=find_packages(),


### PR DESCRIPTION
Both `antlr4-python2-runtime` and `antlr4-python3-runtime` install the `antlr4` package. To avoid conflicts where the wrong version of the runtime may be installed, python version conditions have been added to requirements to install the proper runtime for the proper python version. 

The `enum34` dependency has also been made conditional to avoid creating conflicts with later versions of the python standard library. 