### PR TITLE
Reduce Restrictions of the ANTLRv4 Runtime Dependency for Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     license='BSD',
     python_requires='>=2.7',
     install_requires=[
-        'antlr4-python2-runtime==4.5; python_version<"3"',
-        'antlr4-python3-runtime==4.5; python_version>="3"',
+        'antlr4-python2-runtime>=4.5, <4.6; python_version<"3"',
+        'antlr4-python3-runtime>=4.5, <4.6; python_version>="3"',
         'enum34; python_version<"3.4"'
     ],
     package_data={'': ['*.so']},


### PR DESCRIPTION
The current build system requires the ANTLRv4 version to be 4.5; however, this restriction should be lessened since minor versions maintain compatibility with the currently generated STL parser/lexer used in RTAMT.