### PR TITLE
Optimizing the STL/Discrete/offline temporal operators

### DIFF
--- a/rtamt/operation/stl/discrete_time/offline/always_bounded_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/always_bounded_operation.py
@@ -1,20 +1,16 @@
-import collections
 from rtamt.operation.abstract_operation import AbstractOperation
 
 class AlwaysBoundedOperation(AbstractOperation):
     def __init__(self, begin, end):
         self.begin = begin
         self.end = end
-        self.buffer_bak = collections.deque([float("inf")]*(self.end+1), maxlen=(self.end + 1))
 
     def update(self, samples):
-        out = []
-        buffer = self.buffer_bak.copy()
-
-        for sample in reversed(samples):
-            buffer.append(sample)
-            out_sample = min(list(buffer))
-            out.append(out_sample)
-        out.reverse()
+        diff = self.end - self.begin
+        out  = [min(samples[j:j+diff+1]) for j in range(self.begin, self.end+1)]
+        tmp  = [min(samples[j:j+diff+1]) for j in range(self.end+1,len(samples))]
+        out += tmp
+        tmp  = [float("inf") for j in range(len(samples)-len(out))]
+        out += tmp
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/always_bounded_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/always_bounded_operation.py
@@ -5,20 +5,15 @@ class AlwaysBoundedOperation(AbstractOperation):
     def __init__(self, begin, end):
         self.begin = begin
         self.end = end
+        self.buffer_bak = collections.deque([float("inf")]*(self.end+1), maxlen=(self.end + 1))
 
     def update(self, samples):
         out = []
-        self.buffer = collections.deque(maxlen=(self.end + 1))
+        buffer = self.buffer_bak.copy()
 
-        for i in range(self.end + 1):
-            val = float("inf")
-            self.buffer.append(val)
-
-        for i in range(len(samples)-1, -1, -1):
-            self.buffer.append(samples[i])
-            out_sample = float("inf")
-            for j in range(self.end-self.begin+1):
-                out_sample = min(out_sample, self.buffer[j])
+        for sample in reversed(samples):
+            buffer.append(sample)
+            out_sample = min(list(buffer))
             out.append(out_sample)
         out.reverse()
 

--- a/rtamt/operation/stl/discrete_time/offline/always_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/always_operation.py
@@ -6,10 +6,10 @@ class AlwaysOperation(AbstractOperation):
 
     def update(self, samples):
         out = []
-        self.prev_out = float("inf")
-        for i in range(len(samples)-1, -1, -1):
-            out_sample = min(samples[i], self.prev_out)
-            self.prev_out = out_sample
+        prev_out = float("inf")
+        for sample in reversed(samples):
+            out_sample = min(sample, prev_out)
+            prev_out = out_sample
             out.append(out_sample)
         out.reverse()
         return out

--- a/rtamt/operation/stl/discrete_time/offline/and_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/and_operation.py
@@ -1,5 +1,4 @@
 from rtamt.operation.abstract_operation import AbstractOperation
-import numpy as np
 
 class AndOperation(AbstractOperation):
     def __init__(self):

--- a/rtamt/operation/stl/discrete_time/offline/and_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/and_operation.py
@@ -1,15 +1,12 @@
 from rtamt.operation.abstract_operation import AbstractOperation
-
+import numpy as np
 
 class AndOperation(AbstractOperation):
     def __init__(self):
         pass
 
     def update(self, left, right):
-        out = []
 
-        for i in range(len(left)):
-            out_sample = min(left[i], right[i])
-            out.append(out_sample)
+        out = list(map(min, zip(left,right)))
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/eventually_bounded_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/eventually_bounded_operation.py
@@ -1,21 +1,16 @@
-import collections
 from rtamt.operation.abstract_operation import AbstractOperation
 
 class EventuallyBoundedOperation(AbstractOperation):
     def __init__(self, begin, end):
         self.begin = begin
         self.end = end
-        self.buffer_bak = collections.deque([-float("inf")]*(self.end+1), maxlen=(self.end + 1))
 
     def update(self, samples):
-        out = []
-
-        buffer = self.buffer_bak.copy()
-
-        for sample in reversed(samples):
-            buffer.append(sample)
-            out_sample = max(list(buffer))
-            out.append(out_sample)
-        out.reverse()
+        diff = self.end - self.begin
+        out  = [max(samples[j:j+diff+1]) for j in range(self.begin, self.end+1)]
+        tmp  = [max(samples[j:j+diff+1]) for j in range(self.end+1,len(samples))]
+        out += tmp
+        tmp  = [-float("inf") for j in range(len(samples)-len(out))]
+        out += tmp
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/eventually_bounded_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/eventually_bounded_operation.py
@@ -5,20 +5,16 @@ class EventuallyBoundedOperation(AbstractOperation):
     def __init__(self, begin, end):
         self.begin = begin
         self.end = end
+        self.buffer_bak = collections.deque([-float("inf")]*(self.end+1), maxlen=(self.end + 1))
 
     def update(self, samples):
         out = []
-        self.buffer = collections.deque(maxlen=(self.end + 1))
 
-        for i in range(self.end + 1):
-            val = - float("inf")
-            self.buffer.append(val)
+        buffer = self.buffer_bak.copy()
 
-        for i in range(len(samples)-1, -1, -1):
-            self.buffer.append(samples[i])
-            out_sample = -float("inf")
-            for j in range(self.end - self.begin + 1):
-                out_sample = max(out_sample, self.buffer[j])
+        for sample in reversed(samples):
+            buffer.append(sample)
+            out_sample = max(list(buffer))
             out.append(out_sample)
         out.reverse()
 

--- a/rtamt/operation/stl/discrete_time/offline/eventually_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/eventually_operation.py
@@ -7,10 +7,10 @@ class EventuallyOperation(AbstractOperation):
 
     def update(self, samples):
         out = []
-        self.prev_out = -float("inf")
-        for i in range(len(samples)-1, -1, -1):
-            out_sample = max(samples[i], self.prev_out)
-            self.prev_out = out_sample
+        prev_out = -float("inf")
+        for sample in reversed(samples):
+            out_sample = max(sample, prev_out)
+            prev_out = out_sample
             out.append(out_sample)
         out.reverse()
         return out

--- a/rtamt/operation/stl/discrete_time/offline/fall_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/fall_operation.py
@@ -6,11 +6,8 @@ class FallOperation(AbstractOperation):
         pass
 
     def update(self, samples):
-        out = []
-        self.prev = float("inf")
-        for sample in samples:
-            out_sample = min(self.prev, - sample)
-            self.prev = sample
-            out.append(out_sample)
+        prev = samples[:-1]
+        prev.insert(0,float("inf"))
+        out = [min(p,-s) for p,s in zip(prev,samples)]
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/historically_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/historically_operation.py
@@ -6,12 +6,11 @@ class HistoricallyOperation(AbstractOperation):
 
     def update(self, samples):
         out = []
-        self.prev_out = float("inf")
+        prev_out = float("inf")
 
         for sample in samples:
-            out_sample = min(sample, self.prev_out)
-            self.prev_out = out_sample
+            out_sample = min(sample, prev_out)
+            prev_out = out_sample
             out.append(out_sample)
         return out
 
-        return out

--- a/rtamt/operation/stl/discrete_time/offline/iff_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/iff_operation.py
@@ -6,10 +6,7 @@ class IffOperation(AbstractOperation):
         pass
 
     def update(self, left, right):
-        out = []
 
-        for i in range(len(left)):
-            out_sample = -abs(left[i] - right[i])
-            out.append(out_sample)
+        out = [-abs(l,r) for l,r in zip(left,right)]
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/implies_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/implies_operation.py
@@ -6,10 +6,7 @@ class ImpliesOperation(AbstractOperation):
         pass
 
     def update(self, left, right):
-        out = []
 
-        for i in range(len(left)):
-            out_sample = max(-left[i], right[i])
-            out.append(out_sample)
+        out = [max(-l,r) for l,r in zip(left,right)]
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/next_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/next_operation.py
@@ -5,12 +5,8 @@ class NextOperation(AbstractOperation):
         pass
 
     def update(self, samples):
-        out = []
-        self.nxt = float("inf")
-        for i in range(len(samples)-1, -1, -1):
-            out_sample = self.nxt
-            self.nxt = samples[i]
-            out.append(out_sample)
-        out.reverse()
+
+        out = samples[1:]
+        out.append(float("inf"))
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/not_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/not_operation.py
@@ -6,8 +6,7 @@ class NotOperation(AbstractOperation):
         pass
 
     def update(self, samples):
-        out = []
-        for sample in samples:
-            out_sample = - sample
-            out.append(out_sample)
+
+        out = [ -sample for sample in samples]
+
         return out

--- a/rtamt/operation/stl/discrete_time/offline/once_bounded_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/once_bounded_operation.py
@@ -5,22 +5,15 @@ class OnceBoundedOperation(AbstractOperation):
     def __init__(self, begin, end):
         self.begin = begin
         self.end = end
+        self.buffer_bak = collections.deque([-float("inf")]*(self.end+1), maxlen=(self.end + 1))
 
     def update(self, samples):
         out = []
-        self.buffer = collections.deque(maxlen=(self.end + 1))
-
-        for i in range(self.end + 1):
-            val = - float("inf")
-            self.buffer.append(val)
+        buffer = self.buffer_bak.copy()
 
         for sample in samples:
-            self.buffer.append(sample)
-            out_sample = -float("inf")
-            for i in range(self.end - self.begin + 1):
-                out_sample = max(out_sample, self.buffer[i])
+            buffer.append(sample)
+            out_sample = max(list(buffer))
             out.append(out_sample)
-
-        return out
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/once_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/once_operation.py
@@ -7,11 +7,9 @@ class OnceOperation(AbstractOperation):
 
     def update(self, samples):
         out = []
-        self.prev_out = -float("inf")
+        prev_out = -float("inf")
         for sample in samples:
-            out_sample = max(sample, self.prev_out)
-            self.prev_out = out_sample
+            out_sample = max(sample, prev_out)
+            prev_out = out_sample
             out.append(out_sample)
-        return out
-
         return out

--- a/rtamt/operation/stl/discrete_time/offline/or_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/or_operation.py
@@ -5,10 +5,7 @@ class OrOperation(AbstractOperation):
         pass
 
     def update(self, left, right):
-        out = []
 
-        for i in range(len(left)):
-            out_sample = max(left[i], right[i])
-            out.append(out_sample)
+        out = list(map(max, zip(left,right)))
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/previous_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/previous_operation.py
@@ -6,10 +6,10 @@ class PreviousOperation(AbstractOperation):
 
     def update(self, samples):
         out = []
-        self.prev = float("inf")
+        prev = float("inf")
         for sample in samples:
-            out_sample = self.prev
-            self.prev = sample
+            out_sample = prev
+            prev = sample
             out.append(out_sample)
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/rise_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/rise_operation.py
@@ -5,11 +5,8 @@ class RiseOperation(AbstractOperation):
         pass
 
     def update(self, samples):
-        out = []
-        self.prev = -float("inf")
-        for sample in samples:
-            out_sample = min(- self.prev, sample)
-            self.prev = sample
-            out.append(out_sample)
+        prev = samples[:-1]
+        prev.insert(0,-float("inf"))
+        out = [min(-p,s) for p,s in zip(prev,samples)]
 
         return out

--- a/rtamt/operation/stl/discrete_time/offline/until_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/until_operation.py
@@ -2,16 +2,17 @@ from rtamt.operation.abstract_operation import AbstractOperation
 
 class UntilOperation(AbstractOperation):
     def __init__(self):
-        self.next_out = -float("inf")
+        # self.next_out = -float("inf")
+        pass
 
     def update(self, left, right):
         out = []
-        self.next_out = -float("inf")
+        next_out = -float("inf")
 
         for i in range(len(left)-1, -1, -1):
-            out_sample = min(left[i], self.next_out)
+            out_sample = min(left[i], next_out)
             out_sample = max(out_sample, right[i])
-            self.next_out = out_sample;
+            next_out = out_sample;
             out.append(out_sample)
         out.reverse()
 

--- a/rtamt/operation/stl/discrete_time/offline/xor_operation.py
+++ b/rtamt/operation/stl/discrete_time/offline/xor_operation.py
@@ -1,14 +1,12 @@
 from rtamt.operation.abstract_operation import AbstractOperation
+# import numpy as np
 
 class XorOperation(AbstractOperation):
     def __init__(self):
         pass
 
     def update(self, left, right):
-        out = []
 
-        for i in range(len(left)):
-            out_sample = abs(left[i] - right[i])
-            out.append(out_sample)
+        out = [abs(l-r) for l,r in zip(left,right)]
 
         return out

--- a/rtamt/spec/stl/discrete_time/specification.py
+++ b/rtamt/spec/stl/discrete_time/specification.py
@@ -197,10 +197,7 @@ class STLDiscreteTimeSpecification(LTLDiscreteTimeSpecification):
         # The evaluation done wrt the discrete counter (logical time)
         out = self.offline_evaluator.evaluate(self.top, [length])
 
-        out_t = []
-        for i in range(len(ts)):
-            out_sample = [ts[i], out[i]]
-            out_t.append(out_sample)
+        out_t = [[a[0],a[1]] for a in zip(ts,out)]
         out = out_t
 
         return out


### PR DESCRIPTION
I've uploaded my ideas about how to make the operations faster, as you requested.
Due to lack of time, my testing was insufficient, and I've only checked that it works for me.
So please, review thoroughly. 

What I've done to increase speeds:
- mainly list comprehensions, zips, and maps instead of regular for loops, and nested for loops.
- removed some unnecessary references to attributes that may take time (like self.prev -> prev)

When is it especially useful:
- long signals
- many evaluation calls
