### PR TITLE
Fix #193 : Negation not working in the python STL offline discrete time monitor

### DIFF
--- a/rtamt/semantics/stl/discrete_time/offline/ast_visitor.py
+++ b/rtamt/semantics/stl/discrete_time/offline/ast_visitor.py
@@ -133,6 +133,11 @@ class StlDiscreteTimeOfflineAstVisitor(StlAstVisitor):
         sample_return = [ -i for i in sample]
         return sample_return
 
+    def visitNegate(self, node, *args, **kwargs):
+        sample = self.visit(node.children[0], *args, **kwargs)
+
+        sample_return = [ -i for i in sample]
+        return sample_return
 
     def visitAnd(self, node, *args, **kwargs):
         sample_left  = self.visit(node.children[0], *args, **kwargs)


### PR DESCRIPTION
This solves issue #193 by defining a visitNegate function in the ast_visitor.
I defined the function in the same way as visitNot.