### PR TITLE
remove duplicate childrne in addition syntax node

### DIFF
--- a/rtamt/syntax/node/arithmetic/addition.py
+++ b/rtamt/syntax/node/arithmetic/addition.py
@@ -21,9 +21,6 @@ class Addition(BinaryNode):
         """
         super(Addition, self).__init__(child1, child2)
 
-        self.add_child(child1)
-        self.add_child(child2)
-
         self.in_vars = child1.in_vars + child2.in_vars
         self.out_vars = child1.out_vars + child2.out_vars
 


### PR DESCRIPTION
the children of the addition node are already added when calling the __init__ function of the BinaryNode superclass. Adding again in the Addition node class duplicates them. This merge request removes the adding of the children in the Addition node class.