### PR TITLE
solving #197

### DIFF
--- a/rtamt/semantics/stl/discrete_time/offline/ast_visitor.py
+++ b/rtamt/semantics/stl/discrete_time/offline/ast_visitor.py
@@ -42,7 +42,7 @@ class StlDiscreteTimeOfflineAstVisitor(StlAstVisitor):
             for v in var:
                 sample_return.append(operator.attrgetter(node.field)(v))
         else:
-            sample_return = var
+            sample_return = list(var)
         return sample_return
 
 

--- a/rtamt/semantics/stl/discrete_time/offline/ast_visitor.py
+++ b/rtamt/semantics/stl/discrete_time/offline/ast_visitor.py
@@ -377,7 +377,7 @@ class StlDiscreteTimeOfflineAstVisitor(StlAstVisitor):
         begin, end = self.time_unit_transformer(node)
         sample_len = len(sample)
         if sample_len <= end:
-            sample += [float('inf')] * (end - sample_len + 1)
+            sample = sample + [float('inf')] * (end - sample_len + 1)
 
         diff = end - begin
         sample_return  = [min(sample[j:j+diff+1]) for j in range(begin, end+1)]
@@ -393,7 +393,7 @@ class StlDiscreteTimeOfflineAstVisitor(StlAstVisitor):
         sample_len = len(sample)
 
         if sample_len <= end:
-            sample += [-float('inf')] * (end - sample_len + 1)
+            sample = sample + [-float('inf')] * (end - sample_len + 1)
 
         diff = end - begin
         sample_return  = [max(sample[j:j+diff+1]) for j in range(begin, end+1)]

--- a/rtamt/semantics/stl/discrete_time/offline/ast_visitor.py
+++ b/rtamt/semantics/stl/discrete_time/offline/ast_visitor.py
@@ -1,6 +1,7 @@
 import math
 import operator
 import collections
+import copy
 
 from rtamt.syntax.ast.visitor.stl.ast_visitor import StlAstVisitor
 from rtamt.semantics.enumerations.comp_oper import StlComparisonOperator
@@ -11,7 +12,7 @@ class StlDiscreteTimeOfflineAstVisitor(StlAstVisitor):
 
     def visit(self, node, *args, **kwargs):
         result = super(StlDiscreteTimeOfflineAstVisitor, self).visit(node, *args, **kwargs)
-        self.ast.results[node] = result
+        self.ast.results[node] = copy.deepcopy(result)
         return result
 
     def visitPredicate(self, node, *args, **kwargs):


### PR DESCRIPTION
Pull request to address #197 : [Side-effects in StlDiscreteTimeOfflineAstVisitor](https://github.com/nickovic/rtamt/issues/197).

This PR both makes a deep copy of the results of the visit to a node's children and avoids in-place computations in the node visitor functions to avoid side effects.