### PR TITLE
Fix TextIO import error

### DIFF
--- a/rtamt/antlr/parser/ltl/LtlLexer.py
+++ b/rtamt/antlr/parser/ltl/LtlLexer.py
@@ -1,9 +1,13 @@
 # Generated from LtlLexer.g4 by ANTLR 4.7.2
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
 import sys
 
+# Directly import from typing module if available
+if sys.version_info >= (3, 6):
+    from typing import TextIO
+else:
+    from typing.io import TextIO
 
 
 def serializedATN():

--- a/rtamt/antlr/parser/ltl/LtlParser.py
+++ b/rtamt/antlr/parser/ltl/LtlParser.py
@@ -2,9 +2,13 @@
 # encoding: utf-8
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
 import sys
 
+# Directly import from typing module if available
+if sys.version_info >= (3, 6):
+    from typing import TextIO
+else:
+    from typing.io import TextIO
 
 def serializedATN():
     with StringIO() as buf:

--- a/rtamt/antlr/parser/stl/LtlLexer.py
+++ b/rtamt/antlr/parser/stl/LtlLexer.py
@@ -1,9 +1,13 @@
 # Generated from LtlLexer.g4 by ANTLR 4.7.2
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
 import sys
 
+# Directly import from typing module if available
+if sys.version_info >= (3, 6):
+    from typing import TextIO
+else:
+    from typing.io import TextIO
 
 
 def serializedATN():

--- a/rtamt/antlr/parser/stl/StlParser.py
+++ b/rtamt/antlr/parser/stl/StlParser.py
@@ -2,8 +2,13 @@
 # encoding: utf-8
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
 import sys
+
+# Directly import from typing module if available
+if sys.version_info >= (3, 6):
+    from typing import TextIO
+else:
+    from typing.io import TextIO
 
 
 def serializedATN():


### PR DESCRIPTION
When using Python versions >= 3.12, importing RTAMT produces the following error:

```
Traceback (most recent call last):
  File "/home/runner/work/psy-taliro/psy-taliro/examples/f16.py", line 13, in <module>
    from staliro.specifications import rtamt
  File "/home/runner/work/psy-taliro/psy-taliro/src/staliro/specifications/rtamt.py", line 6, in <module>
    from rtamt import StlDenseTimeSpecification, StlDiscreteTimeSpecification
  File "/home/runner/.local/share/hatch/env/virtual/psy-taliro/dEx5JRFg/psy-taliro/lib/python3.13/site-packages/rtamt/__init__.py", line 5, in <module>
    from rtamt.spec.stl.discrete_time.specification import StlDiscreteTimeSpecification
  File "/home/runner/.local/share/hatch/env/virtual/psy-taliro/dEx5JRFg/psy-taliro/lib/python3.13/site-packages/rtamt/spec/stl/discrete_time/specification.py", line 3, in <module>
    from rtamt.syntax.ast.parser.stl.specification_parser import StlAst
  File "/home/runner/.local/share/hatch/env/virtual/psy-taliro/dEx5JRFg/psy-taliro/lib/python3.13/site-packages/rtamt/syntax/ast/parser/stl/specification_parser.py", line 2, in <module>
    from rtamt.syntax.ast.parser.stl.parser_visitor import StlAstParserVisitor
  File "/home/runner/.local/share/hatch/env/virtual/psy-taliro/dEx5JRFg/psy-taliro/lib/python3.13/site-packages/rtamt/syntax/ast/parser/stl/parser_visitor.py", line 4, in <module>
    from rtamt.antlr.parser.stl.StlParserVisitor import StlParserVisitor
  File "/home/runner/.local/share/hatch/env/virtual/psy-taliro/dEx5JRFg/psy-taliro/lib/python3.13/site-packages/rtamt/antlr/parser/stl/StlParserVisitor.py", line 2, in <module>
    from antlr4 import *
  File "/home/runner/.local/share/hatch/env/virtual/psy-taliro/dEx5JRFg/psy-taliro/lib/python3.13/site-packages/antlr4/__init__.py", line 5, in <module>
    from antlr4.CommonTokenStream import CommonTokenStream
  File "/home/runner/.local/share/hatch/env/virtual/psy-taliro/dEx5JRFg/psy-taliro/lib/python3.13/site-packages/antlr4/CommonTokenStream.py", line 33, in <module>
    from antlr4.Lexer import Lexer
  File "/home/runner/.local/share/hatch/env/virtual/psy-taliro/dEx5JRFg/psy-taliro/lib/python3.13/site-packages/antlr4/Lexer.py", line 12, in <module>
    from typing.io import TextIO
ModuleNotFoundError: No module named 'typing.io'; 'typing' is not a package
```

The `typing.io` module was [deprecated in Python 3.8 and was scheduled for removal in 3.12](https://docs.python.org/3.9/library/typing.html#typing.IO), and the types were moved into the base `typing` module as of Python 3.6. The current usage of `typing.io` in some RTAMT modules means that newer versions of Python are not supported.

This fix adds a guard that selects the correct import for the `TextIO` type depending on the version reported by `sys.version_info`. This approach was chosen rather than just fixing the import to maximize backward compatibility, since the library currently indicates that it supports Python versions earlier than 3.6.