### PR TITLE
Fix KeyError in cpp online update when a variable has no online operator

### DIFF
--- a/rtamt/semantics/abstract_dense_time_online_interpreter.py
+++ b/rtamt/semantics/abstract_dense_time_online_interpreter.py
@@ -65,7 +65,8 @@ class AbstractDenseTimeOnlineInterpreter(AbstractOnlineInterpreter, DenseTimeInt
             var_object = data[1]
             if data[0] in self.ast.free_vars:
                 self.ast.var_object_dict[var_name] = var_object
-                self.online_operator_dict[var_name].sample = var_object
+                if var_name in self.online_operator_dict:
+                    self.online_operator_dict[var_name].sample = var_object
 
 class DenseTimeOnlineUpdateVisitor(AbstractOnlineUpdateVisitor):
     def visitVariable(self, node, online_operator_dict, var_object_dict):

--- a/rtamt/semantics/abstract_discrete_time_online_interpreter.py
+++ b/rtamt/semantics/abstract_discrete_time_online_interpreter.py
@@ -63,7 +63,8 @@ class AbstractDiscreteTimeOnlineInterpreter(AbstractOnlineInterpreter, DiscreteT
             var_value = data[1]
             if data[0] in self.ast.free_vars:
                 self.ast.var_object_dict[var_name] = var_value
-                self.online_operator_dict[var_name].sample = var_value
+                if var_name in self.online_operator_dict:
+                    self.online_operator_dict[var_name].sample = var_value
 
     @property
     def update_counter(self):


### PR DESCRIPTION
## Summary

`update()` raises `KeyError` whenever a variable in `ast.free_vars` has no entry in
`online_operator_dict`. On the C++ online backend this happens for every variable, so the
backend is unusable: 62 of the 106 tests in `tests/cpp` error out. The same defect is
reachable on the pure-Python backends when a variable is declared but does not occur in
the specification.

## Root cause

`set_variable_to_ast_from_dataset()` assumes every free variable has an online operator:

```python
if data[0] in self.ast.free_vars:
    self.ast.var_object_dict[var_name] = var_value
    self.online_operator_dict[var_name].sample = var_value   # KeyError
```

`ast.free_vars` is populated by `declare_var()`, while `online_operator_dict` is populated
by the AST visitor from the parsed specification. Two cases make them diverge:

1. `StlDiscreteTimeOnlineAstVisitorCpp` does not implement `visitVariable`, so on the C++
   backend no variable is ever registered. Every other online visitor implements it.
2. A variable is declared but does not appear in the specification. This affects all
   backends and is not covered by the test suite.

## Reproducing

Build the C++ backend:

```bash
cd rtamt
mkdir build && cd build
cmake -DPythonVersion=3 ../
make
```

### Case 1 — C++ backend, test suite

```bash
python3 -m unittest discover tests/
```

```
Ran 597 tests in 0.18s

FAILED (errors=62)
```

All 62 errors are in `tests/cpp`, all with the same traceback:

```
  File "rtamt/semantics/abstract_discrete_time_online_interpreter.py", line 66, in set_variable_to_ast_from_dataset
    self.online_operator_dict[var_name].sample = var_value
KeyError: 'req'
```

| Test module | Errors |
| --- | --- |
| `cpp.test_stl_discrete_time_online_specification_cpp` | 33 |
| `cpp.test_stl_reset_cpp` | 28 |
| `cpp.test_stl_sampling_time_units_cpp` | 1 |

### Case 1 — C++ backend, minimal example

```python
import rtamt

spec = rtamt.StlDiscreteTimeOnlineSpecificationCpp()
spec.declare_var('a', 'float')
spec.declare_var('b', 'float')
spec.spec = 'eventually[0,1] (a >= b);'
spec.parse()
spec.pastify()

print(spec.update(0, [('a', 100.0), ('b', 20.0)]))   # KeyError: 'a'
print(spec.update(1, [('a',  -1.0), ('b',  2.0)]))
print(spec.update(2, [('a',  -2.0), ('b', -10.0)]))
```

```
  File "rtamt/semantics/abstract_discrete_time_online_interpreter.py", line 66, in set_variable_to_ast_from_dataset
    self.online_operator_dict[var_name].sample = var_value
KeyError: 'a'
```

## Fix

Assign the sample only when the variable has an online operator, in both the discrete-time
and dense-time online interpreters:

```python
self.ast.var_object_dict[var_name] = var_value
if var_name in self.online_operator_dict:
    self.online_operator_dict[var_name].sample = var_value
```


## Verification

```
python3 -m unittest discover tests/
Ran 597 tests in 0.18s

OK
```

The Case 1 example now prints `80.0 / 80.0 / 8.0`, identical to the pure-Python
`StlDiscreteTimeSpecification` on the same input.
